### PR TITLE
client: support new authentication flow with access_token from webauth

### DIFF
--- a/recipes/1.Login/README.rst
+++ b/recipes/1.Login/README.rst
@@ -1,18 +1,22 @@
 one_off_login.py
 ----------------
 
-Minimal example to login into Steam, print some account info and exit.
+Minimal example to login into Steam:
+1) webauth login using ``cli_login()``
+   supports SteamGuard and Email codes as well as app confirmation
+2) steam login using the webauth token
+3) print some account info and exit
 No information is persisted to disk.
 
 diy_one_off_login.py
 --------------------
 
-Same as above, we make our own prompts instead of using ``cli_login()``
+Same as above, but we make our own prompts instead of using ``cli_login()``.
 
 persistent_login.py
 -------------------
 
 In this example, after the login prompt, the client will remain connected until interrupted.
 The client will attempt to reconnect after losing network connectivity or when steam is down.
-A sentry file is persisted to disk for each account.
+A file file is persisted to disk with the account information: ``credentials.json``.
 

--- a/recipes/1.Login/diy_one_off_login.py
+++ b/recipes/1.Login/diy_one_off_login.py
@@ -1,7 +1,6 @@
-from __future__ import print_function
 from getpass import getpass
 from steam.client import SteamClient
-
+import steam.webauth as wa
 
 print("One-off login recipe")
 print("-"*20)
@@ -11,24 +10,23 @@ LOGON_DETAILS = {
     'password': getpass("Password: "),
 }
 
+webauth = wa.WebAuth()
+
+try:
+    webauth.login(**LOGON_DETAILS)
+except wa.TwoFactorCodeRequired:
+    webauth.login(code=input("Enter SteamGuard Code: "))
+except wa.EmailCodeRequired:
+    webauth.login(code=input("Enter Email Code: "))
+
 client = SteamClient()
 
 @client.on('error')
 def error(result):
     print("Logon result:", repr(result))
 
-@client.on('auth_code_required')
-def auth_code_prompt(is_2fa, mismatch):
-    if is_2fa:
-        code = input("Enter 2FA Code: ")
-        client.login(two_factor_code=code, **LOGON_DETAILS)
-    else:
-        code = input("Enter Email Code: ")
-        client.login(auth_code=code, **LOGON_DETAILS)
-
-
 try:
-    client.login(**LOGON_DETAILS)
+    client.login(webauth.username, access_token=webauth.refresh_token)
 except:
     raise SystemExit
 

--- a/recipes/1.Login/one_off_login.py
+++ b/recipes/1.Login/one_off_login.py
@@ -1,13 +1,14 @@
-from __future__ import print_function
 from steam.client import SteamClient
 from steam.enums import EResult
-
-client = SteamClient()
+from steam.webauth import WebAuth
 
 print("One-off login recipe")
 print("-"*20)
 
-result = client.cli_login()
+webauth = WebAuth()
+webauth.cli_login(input("Steam user: "))
+client = SteamClient()
+result = client.login(webauth.username, access_token=webauth.refresh_token)
 
 if result != EResult.OK:
     print("Failed to login: %s" % repr(result))

--- a/recipes/1.Login/persistent_login.py
+++ b/recipes/1.Login/persistent_login.py
@@ -1,13 +1,31 @@
+import json
 import logging
+import os
 from steam.client import SteamClient
 from steam.enums import EResult
+from steam.webauth import WebAuth
 
 # setup logging
 logging.basicConfig(format="%(asctime)s | %(message)s", level=logging.INFO)
 LOG = logging.getLogger()
 
+# file to save/load credentials
+CREDENTIALS = 'credentials.json'
+
+if os.path.exists(CREDENTIALS):
+    with open(CREDENTIALS) as f:
+        credentials = json.load(f)
+else:
+    webauth = WebAuth()
+    webauth.cli_login(input("Steam user: "))
+    credentials = {
+        'username': webauth.username,
+        'refresh_token': webauth.refresh_token,
+    }
+    with open(CREDENTIALS, 'w') as f:
+        json.dump(credentials, f, indent=4)
+
 client = SteamClient()
-client.set_credential_location(".")  # where to store sentry files and other stuff
 
 @client.on("error")
 def handle_error(result):
@@ -15,8 +33,7 @@ def handle_error(result):
 
 @client.on("channel_secured")
 def send_login():
-    if client.relogin_available:
-        client.relogin()
+    client.login(credentials['username'], access_token=credentials['refresh_token'])
 
 @client.on("connected")
 def handle_connected():
@@ -29,10 +46,8 @@ def handle_reconnect(delay):
 @client.on("disconnected")
 def handle_disconnect():
     LOG.info("Disconnected.")
-
-    if client.relogin_available:
-        LOG.info("Reconnecting...")
-        client.reconnect(maxdelay=30)
+    LOG.info("Reconnecting...")
+    client.reconnect(maxdelay=30)
 
 @client.on("logged_on")
 def handle_after_logon():
@@ -44,18 +59,17 @@ def handle_after_logon():
     LOG.info("-"*30)
     LOG.info("Press ^C to exit")
 
-
 # main bit
 LOG.info("Persistent logon recipe")
 LOG.info("-"*30)
 
+result = client.connect()
+
+if result != EResult.OK:
+    LOG.info("Failed to login: %s" % repr(result))
+    raise SystemExit
+
 try:
-    result = client.cli_login()
-
-    if result != EResult.OK:
-        LOG.info("Failed to login: %s" % repr(result))
-        raise SystemExit
-
     client.run_forever()
 except KeyboardInterrupt:
     if client.connected:

--- a/steam/__init__.py
+++ b/steam/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.1"
+__version__ = "1.6.0"
 __author__ = "Rossen Georgiev"
 
-version_info = (1, 5, 1)
+version_info = (1, 6, 0)

--- a/steam/enums/common.py
+++ b/steam/enums/common.py
@@ -391,8 +391,10 @@ class EOSType(SteamIntEnum):
     Win2012R2 = 15
     Windows10 = 16
     Win2016 = 17
-    WinMAX = 18
-    Max = 26
+    Win2019 = 18
+    Win2022 = 19
+    Win11 = 20
+    WinMAX = 21
 
 
 class EFriendRelationship(SteamIntEnum):

--- a/steam/webauth.py
+++ b/steam/webauth.py
@@ -61,7 +61,7 @@ from getpass import getpass
 import six
 import requests
 
-from steam.enums.proto import EAuthSessionGuardType
+from steam.enums.proto import EAuthSessionGuardType, EAuthTokenPlatformType, ESessionPersistence
 from steam.steamid import SteamID
 from steam.utils.web import generate_session_id
 from steam.core.crypto import rsa_publickey, pkcs1v15_encrypt
@@ -210,8 +210,8 @@ class WebAuth(object):
              'encrypted_password': account_encrypted_password,
              'encryption_timestamp': time_stamp,
              'remember_login': '1',
-             'platform_type': '2',
-             'persistence': '1',
+             'platform_type': EAuthTokenPlatformType.WebBrowser,
+             'persistence': ESessionPersistence.Persistent,
              'website_id': 'Community',
              },
             'IAuthentication',

--- a/steam/webauth.py
+++ b/steam/webauth.py
@@ -387,7 +387,7 @@ class WebAuth(object):
                 )
             except LoginIncorrect:
                 prompt = ("Enter password for %s: " if not password else "Invalid password for %s. Enter password:")
-                password = getpass(prompt % repr(self.username))
+                password = getpass(prompt % repr(username))
                 continue
             except TwoFactorAuthNotProvided:
                 # 2FA handling

--- a/steam/webauth.py
+++ b/steam/webauth.py
@@ -210,7 +210,9 @@ class WebAuth(object):
              'encrypted_password': account_encrypted_password,
              'encryption_timestamp': time_stamp,
              'remember_login': '1',
-             'platform_type': EAuthTokenPlatformType.WebBrowser,
+             # with WebBrowser, JWT audience contains just web
+             # but with SteamClient, JWT audience contains client and web
+             'platform_type': EAuthTokenPlatformType.SteamClient,
              'persistence': ESessionPersistence.Persistent,
              'website_id': 'Community',
              },

--- a/steam/webauth.py
+++ b/steam/webauth.py
@@ -248,7 +248,7 @@ class WebAuth(object):
             self.refresh_token = resp['response']['refresh_token']
             self.access_token = resp['response']['access_token']
         except KeyError:
-            raise TwoFactorAuthNotProvided('Authentication requires 2fa token, which is not provided or invalid')
+            raise TwoFactorCodeRequired('Authentication requires 2fa token, which is not provided or invalid')
 
     def _finalizeLogin(self):
         self.sessionID = generate_session_id()
@@ -389,7 +389,7 @@ class WebAuth(object):
                 prompt = ("Enter password for %s: " if not password else "Invalid password for %s. Enter password:")
                 password = getpass(prompt % repr(username))
                 continue
-            except TwoFactorAuthNotProvided:
+            except TwoFactorCodeRequired:
                 # 2FA handling
                 allowed = set(self.allowed_confirmations)
                 if allowed.isdisjoint(SUPPORTED_AUTH_TYPES):
@@ -419,7 +419,7 @@ class WebAuth(object):
                         try:
                             self._pollLoginStatus() # test to see if they've authenticated via app
                             break
-                        except TwoFactorAuthNotProvided:
+                        except TwoFactorCodeRequired:
                             # they've not authenticated via the app, let's see if we can use their provided code
                             pass
 
@@ -429,7 +429,7 @@ class WebAuth(object):
                         try:
                             self._pollLoginStatus()
                             break
-                        except TwoFactorAuthNotProvided:
+                        except TwoFactorCodeRequired:
                             print("Invalid auth code. Please try again")
                             twofactor_code = ''
                             continue
@@ -569,10 +569,6 @@ class WebAuthException(Exception):
 
 
 class AuthTypeNotSupported(WebAuthException):
-    pass
-
-
-class TwoFactorAuthNotProvided(WebAuthException):
     pass
 
 


### PR DESCRIPTION
Hey @solsticegamestudios / @WinterPhoenix,

I noticed your fork of the sadly abandoned github.com/ValvePython/steam, if you don't mind becoming the new de-facto maintainer, I'd be happy to share my work with you, and I hope we and the open-source community can help you keep it alive. I think a game studio is probably more reliable than random single developers.

Your fork includes the new webauth flow, I kept building on it to fix the Steam client persistent authentication: there's no more sentry, login_key, etc. the client auth is done using the refresh token from the webauth flow, used as an access token, which can be saved (e.g. to disk) and so brings back persistent authentication. Note that it requires the web authentication flow to request a client platform type so the JWT audience contains not just web but also client, so I updated that. I've also updated the recipes, i.e. the examples of how to use the library. And as this is a breaking change for the steam client API, I've bumped the version from 1.5.1 to 1.6.0.

I've separated the work into multiple commits with meaningful descriptions, to carry them and not lose them, please **rebase** (not merge, not squash).

Thanks!

PS: consider updating the README, so people can install from your fork directly: `pip install "git+https://github.com/solsticegamestudios/steam@master#egg=steam[client]"`