### PR TITLE
Ignore invalid Unicode in appinfo.vdf key table

### DIFF
--- a/steam/utils/appcache.py
+++ b/steam/utils/appcache.py
@@ -103,7 +103,7 @@ def parse_appinfo(fp, mapper=None):
 
                 if field_name[-1] == 0:
                     field_name = field_name[0:-1]
-                    field_name = field_name.decode("utf-8")
+                    field_name = field_name.decode('utf-8', 'replace')
 
                     key_table.append(field_name)
                     break


### PR DESCRIPTION
`appinfo.vdf` can contain invalid Unicode characters. ValvePython/vdf replaces invalid Unicode with replacement characters, so do the same here for consistent behavior.