### PR TITLE
fix: SteamAuthenticator.add() incorrectly blocks phone-less accounts

### DIFF
--- a/steam/guard.py
+++ b/steam/guard.py
@@ -14,7 +14,7 @@ Adding an authenticator
     wa.cli_login()
 
     sa = SteamAuthenticator(backend=wa)
-    sa.add()    # SMS code will be send to the account's phone number
+    sa.add()    # activation code will be sent via SMS (or email if no phone is on the account)
     sa.secrets  # dict with authenticator secrets (SAVE THEM!!)
 
     # save the secrets, for example to a file
@@ -178,13 +178,14 @@ class SteamAuthenticator:
 
     def add(self):
         """Add authenticator to an account.
-        The account's phone number will receive a SMS code required for :meth:`finalize`.
+
+        If the account has a verified phone number, Steam will send the activation
+        code via SMS. If no phone number is on the account, Steam sends the code
+        to the account's email address instead. Either way, pass the code to
+        :meth:`finalize` to complete setup.
 
         :raises: :class:`SteamAuthenticatorError`
         """
-        if not self.has_phone_number():
-            raise SteamAuthenticatorError("Account doesn't have a verified phone number")
-
         resp = self._send_request('AddAuthenticator', {
             'steamid': self.backend.steam_id,
             'authenticator_time': int(time()),
@@ -200,9 +201,12 @@ class SteamAuthenticator:
         self.steam_time_offset = int(resp['server_time']) - time()
 
     def finalize(self, activation_code):
-        """Finalize authenticator with received SMS code
+        """Finalize authenticator with the received activation code.
 
-        :param activation_code: SMS code
+        The activation code is delivered via SMS if the account has a verified
+        phone number, or via email otherwise (subject: "Add Authenticator Request").
+
+        :param activation_code: activation code from SMS or email
         :type activation_code: str
         :raises: :class:`SteamAuthenticatorError`
         """


### PR DESCRIPTION
Removed the blocker and added clarity to the docstrings

see #18